### PR TITLE
Update createFileAndPaths function to work on Windows

### DIFF
--- a/src/libraries/Ttc/Freebies/Responsive/Helper.php
+++ b/src/libraries/Ttc/Freebies/Responsive/Helper.php
@@ -288,7 +288,7 @@ class Helper
       }
     }
 
-    $this->createFileAndPaths(JPATH_ROOT . '/media/cached-resp-images/___data___/' . $dirname . '/' . $filename . '.json', \json_encode($srcSets));
+    $this->createFileAndPaths(JPATH_ROOT . '/media/cached-resp-images/___data___/' . $dirname . '/', $filename . '.json', \json_encode($srcSets));
   }
 
   /**
@@ -332,15 +332,10 @@ class Helper
    * @param $dir
    * @param $contents
    */
-  private function createFileAndPaths($dir, $contents)
+  private function createFileAndPaths($dir, $file, $contents)
   {
-    $parts = explode('/', $dir);
-    $file  = array_pop($parts);
-    $dir   = '';
-    foreach ($parts as $part) {
-      if ('' !== $part && !is_dir($dir .= "/$part")) {
-        mkdir($dir);
-      }
+    if (!is_dir($dir)) {
+      mkdir($dir, 0777, true);
     }
     file_put_contents("$dir/$file", $contents);
   }


### PR DESCRIPTION
I was having the same issue as this comment:
https://github.com/ttc-freebies/plugin-responsive-images/issues/39#issuecomment-894804525

I tracked down the issue to the `___data___` directory (and subsequent json files) not being created on Windows systems. The `createFileAndPaths` function was trying to create the directory `/C:\<webroot>/media/cached-resp-images/___data___/` which was failing because of the leading `/`.

This pull request updates the `createFileAndPaths` function to also work on Windows.