### PR TITLE
loading, width and height attributes are duplicated in the fallback i…

### DIFF
--- a/src/libraries/Ttc/Freebies/Responsive/Helper.php
+++ b/src/libraries/Ttc/Freebies/Responsive/Helper.php
@@ -167,11 +167,30 @@ class Helper
 
     // Create the fallback img
     $fallBack = preg_replace(
-      '/src\s*=\s*".+?"/',
-      'src="/media/cached-resp-images/' . $image['dirname'] . '/' . $image['filename'] .
-        $this->separator . $this->validSizes[count($this->validSizes) - 1] . '.' . $image['extension'] . '?version=' . $srcSets->base->version . '"',
+      [
+        '/src\s*=\s*".+?"/',
+        '/width\s*=\s*".+?"/',
+        '/height\s*=\s*".+?"/',
+      ],
+      [
+        'src="/media/cached-resp-images/' . $image['dirname'] . '/' . $image['filename'] . $this->separator . $this->validSizes[count($this->validSizes) - 1] . '.' . $image['extension'] . '?version=' . $srcSets->base->version . '"',
+        'width="' . $srcSets->base->width . '"',
+        'height="' . $srcSets->base->height . '"',
+      ],      
       $image['tag']
     );
+
+    if (preg_match('/width\s*=\s*".+?"/', $fallBack) === 0) {
+      $fallBack = str_replace('<img ', '<img width="' . $srcSets->base->width . '" ', $fallBack);
+    }
+
+    if (preg_match('/height\s*=\s*".+?"/', $fallBack) === 0) {
+      $fallBack = str_replace('<img ', '<img height="' . $srcSets->base->height . '" ', $fallBack);
+    }
+
+    if (preg_match('/loading\s*=\s*".+?"/', $fallBack) === 0) {
+      $fallBack = str_replace('<img ', '<img loading="lazy" ', $fallBack);
+    }
 
     $output .= $fallBack . '</picture>';
 

--- a/src/libraries/Ttc/Freebies/Responsive/Helper.php
+++ b/src/libraries/Ttc/Freebies/Responsive/Helper.php
@@ -173,7 +173,6 @@ class Helper
       $image['tag']
     );
 
-    $fallBack = str_replace('<img ', '<img loading="lazy" width="' . $srcSets->base->width . '" height="' . $srcSets->base->height . '"', $fallBack);
     $output .= $fallBack . '</picture>';
 
     return  $output;


### PR DESCRIPTION
…mg tag

The fallback image that is created from the buildSrcset function looks like this:
`<img loading="lazy" width="400" height="300"src="/media/cached-resp-images/images/..." loading="lazy" width="400" height="300">`

Removing this line the fallback image becomes:
`<img src="/media/cached-resp-images/images/..." loading="lazy" width="400" height="300">`

The loading, width and height attributes should already come from the joomla.html.image layout.